### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from g.__about__ import __version__
+          from g import find_repo_type, run
+          print("g version:", __version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Adds a CI check to verify runtime dependencies and basic functionality of the package.

CI:
- Adds a CI check to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.

Tests:
- Adds a basic functionality test that prints the package version and runs a basic functionality test.