### PR TITLE
py(deps[dev]): Require ruff>=0.16.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -99,6 +99,7 @@ matching reference material.
 - The docs dependency pins track gp-sphinx through `0.0.1a17`, including the `exclude-newer` whitelist needed for the git-pull package family during coordinated pre-release work (#55).
 - Workflow actions moved to their current major releases: `actions/checkout` v7, `actions/cache` v6, `astral-sh/setup-uv` v9.0.0, `codecov/codecov-action` v7, and `dorny/paths-filter` v4. Workflow behavior is unchanged, though setup-uv no longer prunes the uv cache, so the first run after this repopulates it.
 - Minimum `ruff>=0.16.0` (was unpinned), so contributors and CI share the same lint diagnostics and the [ruff 0.16](https://astral.sh/blog/ruff-v0.16.0) formatting of Python code blocks inside Markdown (#63).
+- Linting runs on ruff's curated default rule set with this project's linters layered on top through `extend-select` instead of replacing it, so the default pylint, flake8-bandit, and flake8-pyi checks now apply; `docs/conf.py` carries a scoped ignore for the `exec` that reads the package's metadata module (#63).
 
 ## g 0.0.9 (2026-01-24)
 

--- a/CHANGES
+++ b/CHANGES
@@ -98,6 +98,7 @@ matching reference material.
 - Root `conftest.py` remains type-checked while the temporary docs-extension [mypy](https://mypy-lang.org/) path excludes only the extension-local `docs/_ext/conftest.py` case that caused duplicate module discovery (#46).
 - The docs dependency pins track gp-sphinx through `0.0.1a17`, including the `exclude-newer` whitelist needed for the git-pull package family during coordinated pre-release work (#55).
 - Workflow actions moved to their current major releases: `actions/checkout` v7, `actions/cache` v6, `astral-sh/setup-uv` v9.0.0, `codecov/codecov-action` v7, and `dorny/paths-filter` v4. Workflow behavior is unchanged, though setup-uv no longer prunes the uv cache, so the first run after this repopulates it.
+- Minimum `ruff>=0.16.0` (was unpinned), so contributors and CI share the same lint diagnostics and the [ruff 0.16](https://astral.sh/blog/ruff-v0.16.0) formatting of Python code blocks inside Markdown (#63).
 
 ## g 0.0.9 (2026-01-24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,10 @@ files = [
 target-version = "py310"
 
 [tool.ruff.lint]
-select = [
+# `select` is deliberately unset: ruff 0.16 enables a curated default rule
+# set, and an explicit `select` would replace it rather than extend it.
+# `extend-select` layers this project's additional linters on top.
+extend-select = [
   "E", # pycodestyle
   "F", # pyflakes
   "I", # isort
@@ -168,7 +171,7 @@ select = [
   "PERF", # Perflint
   "RUF", # Ruff-specific rules
   "D", # pydocstyle
-  "FA100",  # future annotations
+  "FA100", # flake8-future-annotations
 ]
 ignore = [
   "COM812", # missing trailing comma, ruff format conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,10 +136,6 @@ sphinx-gp-sitemap = false
 sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
-# TEMPORARY - REVERT BEFORE MERGE. ruff 0.16.0 released 2026-07-23 and is
-# still inside the 3-day cooldown, so the resolver cannot see it. Drop this
-# line once the cooldown clears; the version floor is what holds ruff 0.16.
-ruff = false
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
   "coverage",
   "pytest-cov",
   # Lint
-  "ruff",
+  "ruff>=0.16.0",
   "mypy",
   # Type stubs
   "types-docutils",
@@ -104,7 +104,7 @@ coverage =[
   "pytest-cov",
 ]
 lint = [
-  "ruff",
+  "ruff>=0.16.0",
   "mypy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,10 @@ sphinx-gp-sitemap = false
 sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
+# TEMPORARY - REVERT BEFORE MERGE. ruff 0.16.0 released 2026-07-23 and is
+# still inside the 3-day cooldown, so the resolver cannot see it. Drop this
+# line once the cooldown clears; the version floor is what holds ruff 0.16.
+ruff = false
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,12 @@ required-imports = [
 
 [tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ["F401"]
+"docs/conf.py" = [
+  # Sphinx collects the project's title, copyright, and URLs by exec'ing the
+  # package's `__about__.py` into a dict; `g/__init__.py` re-exports only
+  # `__version__`. The input is a tracked file here, not user data.
+  "S102",
+]
 
 [tool.pytest.ini_options]
 addopts = "--tb=short --no-header --showlocals --doctest-modules"

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,6 @@ sphinx-ux-badges = false
 gp-libs = false
 sphinx-autodoc-docutils = false
 gp-furo-theme = false
-ruff = false
 sphinx-gp-sitemap = false
 sphinx-fonts = false
 sphinx-autodoc-typehints-gp = false

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ sphinx-ux-badges = false
 gp-libs = false
 sphinx-autodoc-docutils = false
 gp-furo-theme = false
+ruff = false
 sphinx-gp-sitemap = false
 sphinx-fonts = false
 sphinx-autodoc-typehints-gp = false
@@ -466,7 +467,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
-    { name = "ruff" },
+    { name = "ruff", specifier = ">=0.16.0" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a36" },
     { name = "sphinx-autodoc-argparse", specifier = "==0.0.1a36" },
@@ -484,7 +485,7 @@ docs = [
 ]
 lint = [
     { name = "mypy" },
-    { name = "ruff" },
+    { name = "ruff", specifier = ">=0.16.0" },
 ]
 testing = [
     { name = "gp-libs", specifier = ">=0.0.19" },
@@ -1251,27 +1252,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Pin** a `ruff>=0.16.0` floor in the `dev` and `lint` dependency groups so contributors and CI resolve the same linter and see the same diagnostics.
- **Relock** `uv.lock` onto ruff 0.16.0.
- **Adopt ruff's default rule set.** `select` becomes `extend-select`, so this project's linters layer on top of ruff's curated default set instead of replacing it. Enabled rules go from 351 to 565.
- **One new finding, scoped as an ignore.** The wider rule set surfaced a single diagnostic — `S102` on the `exec` in `docs/conf.py` — and it is intentional.

## Changes

**pyproject.toml** — `ruff` raised to `>=0.16.0` in `[dependency-groups] dev` and `lint`; `[tool.ruff.lint] select` renamed to `extend-select` with a comment recording why `select` stays unset; `S102` per-file-ignored for `docs/conf.py`.

**uv.lock** — ruff 0.15.22 -> 0.16.0.

**CHANGES** — entries for the floor bump and the rule-set adoption.

## Design decisions

### Why `extend-select` rather than a wider `select`

ruff 0.16 ships a curated default rule set as its recommended baseline. An explicit `select` **replaces** that set rather than extending it, so this project was silently opting out of everything ruff considers a sensible default. There is no token that names the default set from inside `select` — ruff's selector grammar has no `DEFAULT` — so the only way to get defaults-plus-extras is to leave `select` unset and layer the project's linters through `extend-select`.

The alternative of naming whole prefixes (`PL`, `S`, `PYI`, ...) in `select` was rejected: it drags in the full contents of each family rather than the curated subset, which is far noisier for no added signal.

Every `extend-select` entry stays on its own line with a trailing comment naming the linter it selects. `FA100`'s comment now names `flake8-future-annotations` rather than describing the rule.

### The one finding

[S102 (`exec-builtin`)](https://docs.astral.sh/ruff/rules/exec-builtin/) in `docs/conf.py`. Sphinx collects the project's title, copyright, and URLs by exec'ing the package's `__about__.py` into a dict, because `g/__init__.py` re-exports only `__version__`. The exec'd input is a tracked file in this repository, not user data, so the flake8-bandit warning has nothing to warn about here. Scoped as a per-file-ignore on `docs/conf.py` rather than repo-wide, with the reason recorded in the config.

No code changes were needed: nothing else in `src/`, `tests/`, or `docs/` trips a default rule.

### ruff 0.16 rule stabilizations

ruff 0.16.0 stabilizes several rules that live inside prefixes this project already selects, notably [RUF036](https://docs.astral.sh/ruff/rules/none-not-at-end-of-union/), [RUF063](https://docs.astral.sh/ruff/rules/access-annotations-from-class-dict/), and [RUF068](https://docs.astral.sh/ruff/rules/duplicate-entry-in-dunder-all/), plus behavior changes to [UP019](https://docs.astral.sh/ruff/rules/typing-text-str-alias/) and the `B`/`SIM`/`TRY` families. None of them fire here.

ruff 0.16.0 also formats Python and pycon code blocks inside Markdown by default. All Markdown under the repo (including `docs/`) is picked up by `ruff format` and came back already formatted, so there is no churn. `CHANGES` has no `.md` extension and is not in scope for `ruff format`; it stays on the `prettier` path in the `format_markdown` make target.

See https://astral.sh/blog/ruff-v0.16.0 for the full release notes.

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — every file already formatted
- [x] `uv run mypy .` — no issues found
- [x] `uv run py.test` — passes in a normal checkout

Note on running the suite from a linked worktree: `tests/test_cli.py::test_command_line[g-cmd-inside-git-dir]` and `[g-cmd-help-inside-git-dir]` fail there because `find_repo_type` requires `.git` to be a directory, and a linked worktree's `.git` is a file. Both fail identically at the base commit, so this is not a regression from this branch, and CI's plain checkout is unaffected.
